### PR TITLE
Register global variables

### DIFF
--- a/ext/tomlib/tomlib.c
+++ b/ext/tomlib/tomlib.c
@@ -340,11 +340,14 @@ void Init_tomlib(void) {
   id_new = rb_intern("new");
 
   sym_simple = ID2SYM(rb_intern("simple"));
+  rb_global_variable(&sym_simple);
   sym_quoted = ID2SYM(rb_intern("quoted"));
+  rb_global_variable(&sym_quoted);
   sym_escape = ID2SYM(rb_intern("escape"));
+  rb_global_variable(&sym_escape);
 
-  rb_require("date");
   cDate = rb_const_get(rb_cObject, rb_intern("Date"));
+  rb_global_variable(&cDate);
 
   mTomlib = rb_define_module("Tomlib");
   rb_define_singleton_method(mTomlib, "load", tomlib_load, 1);

--- a/lib/tomlib.rb
+++ b/lib/tomlib.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'date'
 require_relative 'tomlib/dumper'
 require_relative 'tomlib/tomlib'
 require_relative 'tomlib/version'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -106,3 +106,15 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 =end
 end
+
+require 'tomlib'
+
+if GC.respond_to?(:verify_compaction_references)
+  # This method was added in Ruby 3.0.0. Calling it this way asks the GC to
+  # move objects around, helping to find object movement bugs.
+  begin
+    GC.verify_compaction_references(double_heap: true, toward: :empty)
+  rescue NotImplementedError
+    # Some platforms don't support compaction
+  end
+end

--- a/spec/tomlib_spec.rb
+++ b/spec/tomlib_spec.rb
@@ -2,7 +2,6 @@
 
 require 'json'
 require 'time'
-require 'tomlib'
 require 'yaml'
 
 def cast_float(value)


### PR DESCRIPTION
Global variable containing Ruby objects must be declared with `rb_global_variable` so that the GC can update the reference when it triggers compaction.

If it's not done it may cause the VM to crash.

In this instance it wasn't really a problem because all the referenced objects are pinned, but it's still good practice.