### PR TITLE
Fix loading the c extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.7.3] - [unreleased]
+
+- [Robert Schulze] Fix loading the C extension on system that don't copy it into the gem install directory
+
 ## [0.7.2] - 2024-02-17
 
 - Remove "double_heap" deprecation warning

--- a/lib/tomlib.rb
+++ b/lib/tomlib.rb
@@ -3,7 +3,7 @@
 require 'date'
 
 require_relative 'tomlib/dumper'
-require_relative 'tomlib/tomlib'
+require 'tomlib/tomlib'
 require_relative 'tomlib/version'
 
 # Main library namespace


### PR DESCRIPTION
Loading the extension shoul rely on $LOAD_PATH for systems where the ext file will not be copied into the gem dir.